### PR TITLE
Add explicit cast for seed

### DIFF
--- a/constexpr-xxh3.h
+++ b/constexpr-xxh3.h
@@ -224,7 +224,7 @@ constexpr uint64_t XXH3_64bits_internal(const T* input, size_t len,
     uint64_t keyed =
         (readLE32(input + len - 4) + (uint64_t(readLE32(input)) << 32)) ^
         ((readLE64(secret + 8) ^ readLE64(secret + 16)) -
-         (seed ^ (uint64_t(swap32(seed)) << 32)));
+         (seed ^ (uint64_t(swap32(uint32_t(seed))) << 32)));
     return rrmxmx(keyed, len);
   } else if (len <= 16) {
     uint64_t input_lo =


### PR DESCRIPTION
Both g++ and clang++ don't warn about this implicit narrowing.
But MSVC shows [C4244] for it.

[C4244] https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244
